### PR TITLE
Use BSL License

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,8 +1,0 @@
-To the fullest extent of the law possible in any and all jurisdictions, contributor agrees to
-transfer all intellectualy property rights (including copyright or patent) to Judica, Inc for code
-or patches submitted to this project.
-
-
-This is a temporary measure, and the code will eventually be released under an open source licensing
-scheme, but the above (aggressive) Contributor License Agreement is in place to permit flexibility
-in choosing a licensing scheme down the line.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+
+Contributor's choice of a joint-owner assigning under CLA below or BSD-new.
+
+Where possible, CLA is preferred over BSD-new.
+
+
+See the original [MariaDB Contributor Agreement](https://mariadb.com/kb/en/mca/) that this agreement
+is based on. This derivative work is available under
+[CC-BY-SA](https://creativecommons.org/licenses/by-sa/3.0/). The modifications are limited to
+parametrizing the MCA, making physical address optional, and formatting.
+
+
+Questions? See the [MCA FAQ](https://mariadb.com/kb/en/mariadb-contributor-agreement-faq/) page.
+
+
+Parameters
+
+Entity: Judica, Inc
+
+E-Mail: `c o n t r i b s [at] j u d i c a (dot) o r g`
+
+# Parametrized MariaDB Contributor Agreement (PMCA)
+
+
+These terms apply to your contribution of materials to a product or project
+owned or managed by us ('project'), and set out the intellectual property
+rights you grant to us (The "Entity") in the contributed material. If
+this contribution is on behalf of a company, the term 'you' will also mean the
+company you identify below. If you agree to be bound by these terms, fill in
+the information requested below and provide your signature. Read this agreement
+carefully before signing.
+
+* The term 'contribution' means any source code, object code, patch, tool,
+  sample, graphic, specification, manual, documentation, or any other material
+  posted, committed or submitted by you to a project. Each submission must
+  explicitly be marked that it's donated under the PMCA.
+* With respect to any worldwide copyrights, or copyright applications and
+  registrations, in your contribution:
+    * you hereby assign to us joint ownership, and to the extent that such
+       assignment is or becomes invalid, ineffective or unenforceable, you hereby
+       grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge,
+       royalty-free, unrestricted license to exercise all rights under those
+       copyrights. This includes, at our option, the right to sub-license these
+       same rights to third parties through multiple levels of sub-licensees or
+       other licensing arrangements;
+    * you agree that each of us can do all things
+       in relation to your contribution as if each of us were the sole owners, and
+       if one of us makes a derivative work of your contribution, the one who makes
+       the derivative work (or has it made) will be the sole owner of that
+       derivative work;
+    * you agree that you will not assert any moral rights in your contribution
+      against us, our licensees or transferees;
+    * you agree that we may register a copyright in your contribution and exercise
+      all ownership rights associated with it; and
+    * you agree that neither of us has any duty to consult with, obtain the
+       consent of, pay or render an accounting to the other for any use or
+       distribution of your contribution.
+* With respect to any patents you grant licenses to without payment to any third party,
+  which would restrict us from using the contributed code as if we would own a
+  shared copyright to it, you hereby grant to us a perpetual, irrevocable,
+  non-exclusive, worldwide, no-charge, royalty-free license to:
+    * make, have
+      made, use, sell, offer to sell, import, and otherwise transfer your
+      contribution in whole or in part, alone or in combination with or included in
+      any product, work or materials arising out of the project to which your
+      contribution was submitted, and
+    * at our option, to sub-license these same rights to third parties through multiple
+      levels of sub-licensees or other licensing arrangements.
+    * Note that you don't give us rights to the patent in any other way than to give us the
+   right to freely use the contributed code in the above ways.
+* Except as set out above, you keep all right, title, and interest in your contribution.
+  The rights that you grant to us under these terms are effective on the date
+  you first submitted a contribution to us, even if your submission took place
+  before the date you sign these terms. Any contribution we make available
+  under any license will also be made available under a suitable FSF (Free
+  Software Foundation) or OSI (Open Source Initiative) approved license.
+* With respect to your contribution, you represent that:
+    * it is an original work and that you can legally grant the rights set out in these
+      terms;
+    * it does not to the best of your knowledge violate any third party's copyrights,
+      trademarks, patents, or other intellectual property rights; and
+    * you are authorized to sign this contract on behalf of your company (if
+       identified below).
+* These terms will be governed by the laws of the Finland. Any choice of law rules will
+  not apply.
+
+## Signatory Information
+
+    Your user name on GitHub:
+    Your contact information (Please print clearly):
+    Your name:
+    Your company's name (if applicable):
+    Email:
+    Mailing address (optional):
+    Telephone (optional):
+    Your signature:
+    Date:
+
+To deliver these terms to us, scan and email to the provided E-Mail.
+
+Parametrized MariaDB Contributor Agreement – version 1.0
+
+Questions? See the [MCA FAQ](https://mariadb.com/kb/en/mariadb-contributor-agreement-faq/) page.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,577 @@
-All rights reserved.
+Business Source License 1.1
 
-This is a temporary measure, and the code will eventually be released under a less restrictive
-license.
+Parameters
 
-See CONTRIBUTING for more information about making patches to this code.
+Licensor:               Judica, Inc.
+Licensed Work:          Transaction UX (tux)
+                        The Licensed Work is (c) 2020 Judica, Inc.
+Licensor E-Mail:        license@judica.org
+Threshold Amount:       $250,000 USD
+Change Date:            2024-08-25
+Change License:         MPL2.0 (Mozilla Public License Version 2.0, included)
+Additional Use Grant:   You may make use of the Licensed Work, provided
+                        that you (or the aggregate usage of any users of
+                        any service you provide) do not use the Licensed
+                        Work to transact with, manage, or otherwise
+                        control in excess of the Threshold Amount of assets
+                        (including but not limited to Bitcoin) for any purpose
+                        in the preceding year. The value of assets is determined
+                        by the "At Risk Funds Rule" and "Integration Rule",
+                        described below.
+
+                        Should you exceed this limit, you have thirty days
+                        to notify Licensor to procure a license before
+                        your rights under the Additional Use Grant
+                        terminate. Your notification, if you are in
+                        breach, must include the amount of assets in
+                        excess of the Threshold Amount exemption.
+                        Notification may be by email to the Licensor
+                        E-Mail.
+
+                        Licensor has no obligation under this agreement to
+                        inform you when you are in breach.
+
+
+                        Integration Rule:
+
+                        The value limitation cap is accounted for and
+                        shared across any and all software you license
+                        from Licensor, including past (unless the
+                        Change Date has passed) or future versions of such
+                        software. Should the Threshold Amount vary across
+                        versions of a products, you may use the greater
+                        amount. Should the Threshold Amount vary across
+                        two different integrated software products, you
+                        may use up to the lesser amount.
+
+                        For the avoidance of doubt, use in the following
+                        non-exhaustive list of situations are likely not
+                        permitted:
+                        1. You use service A with a Threshold of $5M, and
+                           install a severally licensed Plugin B with a
+                           Threshold of $250k, and use Plugin B for $5M in
+                           transactions.
+
+
+
+                        For the avoidance of doubt, use in the following
+                        non-exhaustive list of situations are likely
+                        permitted:
+                        1. You use Licensor's Product A with a Threshold
+                           Amount of $5M, and install a severally licensed
+                           Plugin B by Licensor with a Threshold Amount of
+                           $250k, and use Plugin B for $10,000 in
+                           transactions.
+                        2. You receive more than the Threshold Amount in
+                           Bitcoin through a third party wallet and use the
+                           Licensed Work to create a new transaction spending
+                           the Threshold Amount.
+
+
+
+                        At Risk Funds Rule:
+
+                        If the sum total value of the user's assets over
+                        the period that could be lost, misappropriated, or
+                        otherwise diminished by a malfunction in the
+                        Licensed Work exceeds the Threshold Amount, the
+                        use is not permitted. The user's use of
+                        mitigations or external protections to prevent
+                        malfunction in the Licensed Work are not to be
+                        considered in the evaluation of this rule.
+
+                        For avoidance of doubt, use in following
+                        non-exhaustive list of situations are likely not
+                        permitted:
+                        1. You use Licensed Work version 1 up to the
+                           Threshold Amount and then separately use Licensed
+                           Work version 2 up to the Threshold Amount.
+                        2. You receive one tenth of the Threshold Amount a
+                           day using the Licensed Work, but immediately spend
+                           it, you would be in violation on the eleventh day.
+                        3. You use the Licensed Work on an air-gapped
+                           machine with more than the Threshold Amount and
+                           validate all operations using your own software on
+                           a different machine.
+
+                        Under the following non-exhaustive list of
+                        situations you likely would be permitted:
+                        1. You use the Licensed Work after the Change
+                           Date to manage more than the Threshold Amount.
+                        2. You deposit the Threshold Amount of Bitcoin
+                           using the Licensed Work, and use the coins within the
+                           Licensed Work.
+                        3. You deposit 1/10th the Threshold Amount into
+                           the Licensed Work, and use only that 1/10th amount
+                           in a series of 100 transactions such that your
+                           total assets are not in excess of the Threshold
+                           Amount.
+
+For information about alternative licensing options and pricing please visit:
+https://judica.org/licensing/.
+
+See CONTRIBUTING for more information about contributing to this project.
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License’s text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License’s text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+
+
+
+
+Additional Information Provided by Judica:
+
+
+Change License: MPL2.0 (Mozilla Public License Version 2.0)
+-----------------------------------------------------------------------------
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.
+


### PR DESCRIPTION
See https://perens.com/2017/02/14/bsl-1-1/ for an explanation on why BSL may be a good license for software released by Judica for the time being.


Use MPL2.0 because it's like GPLv3 but without weaknesses around linking options for end users (shouldn't matter for tux, but prefer 1 license across tux, sapio, etc).


Feedback sought:

1) Are the exemptions reasonable? Can they be circumvented (not tight enough). Goal: get good users to pay, people who are going to be in breach willfully likely hard to track down.
2) Will we actually be able to get off the ground with this model?
3) What drawbacks might their be v.s. directly to MPL2 (CLA would stay the same).
4) is the CLA fine?
5) What license should we provide to people who want to use it for more $?