### PR TITLE
fix: AppNavbar menu items not clickable due to draggable class

### DIFF
--- a/src/Data/BitcoinStatusBar.tsx
+++ b/src/Data/BitcoinStatusBar.tsx
@@ -44,7 +44,7 @@ export function BitcoinStatusBar(props: BitcoinStatusBarProps) {
                 bottom: 0,
                 zIndex: (theme) => theme.zIndex.drawer + 1,
             }}
-            className="BitcoinStatusBar"
+            className="BitcoinStatusBar Draggable"
             style={{
                 background: theme.palette.background.default,
                 color: theme.palette.info.main,

--- a/src/UX/AppNavbar.tsx
+++ b/src/UX/AppNavbar.tsx
@@ -31,7 +31,7 @@ export function AppNavbar(props: {
     const dispatch = useDispatch();
 
     return (
-        <Paper className="AppNavBar Draggable" square={true}>
+        <Paper className="AppNavBar" square={true}>
             <List>
                 <MainScreens></MainScreens>
             </List>


### PR DESCRIPTION
`Draggable` class prevented clicking on sidebar menu  due to `-webkit-user-select: none;`. I've moved the Draggable class from `AppNavbar` component to `BitcoinStatusBar` instead.