### PR TITLE
minor readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ via `bitcoin-cli`.
 
 ### Run Sapio
 
-In one terminal run bellow code: `yarn start-react`
+In one terminal run below code: `yarn start-react`
 
 After previous command finishes compiling run: `yarn start-electron`
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,22 @@ contract trees built with [Sapio](https://learn.sapio-lang.org).
 
 ## Getting Started
 
-```
-yarn install
-yarn start-react
-# in a new tab
-yarn start-electron
-```
+### Make sure you have a Bitcoin node running
 
+Before starting Sapio make sure you have a Bitcoin node running and that you've loaded your wallet
+via `bitcoin-cli`.
+
+### Install dependencies
+
+`yarn install`
+
+### Run Sapio
+
+In one terminal run bellow code: `yarn start-react`
+
+After previous command finishes compiling run: `yarn start-electron`
+
+If `start-electron` command doesn't work you can try: `yarn start-electron --disable-seccomp-filter-sandbox`
 
 ## Connecting With Sapio & Bitcoin
 


### PR DESCRIPTION
Currently the app crashes w/o any details if you haven't loaded your wallet yet so I wanted to add this to the README just in case. Also separating the commands for clarity and adding an alternative command with the `--disable-seccomp-filter-sandbox` flag for Fedora users.

cc @prayank23