### PR TITLE
dont crash app when rpc requests fail

### DIFF
--- a/src/Data/BitcoinNode.ts
+++ b/src/Data/BitcoinNode.ts
@@ -136,24 +136,31 @@ export class BitcoinNodeManager {
         };
     }
     async check_balance(): Promise<number> {
-        let results = await window.electron.bitcoin_command([
+        const [result] = await window.electron.bitcoin_command([
             { method: 'getbalance', parameters: [] },
         ]);
-        return results[0];
+        if (result.name === 'RpcError') {
+            throw result;
+        }
+        return result;
     }
     async blockchaininfo(): Promise<any> {
-        return (
-            await window.electron.bitcoin_command([
-                { method: 'getblockchaininfo', parameters: [] },
-            ])
-        )[0];
+        const [result] = await window.electron.bitcoin_command([
+            { method: 'getblockchaininfo', parameters: [] },
+        ]);
+        if (result.name === 'RpcError') {
+            throw result;
+        }
+        return result;
     }
     async get_new_address(): Promise<string> {
-        return (
-            await window.electron.bitcoin_command([
-                { method: 'getnewaddress', parameters: [] },
-            ])
-        )[0];
+        const [result] = await window.electron.bitcoin_command([
+            { method: 'getnewaddress', parameters: [] },
+        ]);
+        if (result.name === 'RpcError') {
+            throw result;
+        }
+        return result;
     }
 
     async send_to_address(amount: number, address: string): Promise<void> {
@@ -165,17 +172,24 @@ export class BitcoinNodeManager {
     }
 
     async list_transactions(count: number): Promise<any> {
-        return (
-            await window.electron.bitcoin_command([
-                { method: 'listtransactions', parameters: ['*', count] },
-            ])
-        )[0];
+        const [result] = await window.electron.bitcoin_command([
+            { method: 'listtransactions', parameters: ['*', count] },
+        ]);
+        if (result.name === 'RpcError') {
+            throw result;
+        }
+        return result
     }
     async generate_blocks(n: number): Promise<void> {
         const addr = await this.get_new_address();
-        await window.electron.bitcoin_command([
-            { method: 'generatetoaddress', parameters: [10, addr] },
+        console.log(addr);
+        const [result] = await window.electron.bitcoin_command([
+            { method: 'generatetoaddress', parameters: [n, addr] },
         ]);
+        if (result.name === 'RpcError') {
+            throw result;
+        }
+        return result;
     }
     // get info about transactions
     async get_confirmed_transactions(

--- a/src/Data/BitcoinNode.ts
+++ b/src/Data/BitcoinNode.ts
@@ -53,6 +53,11 @@ export function update_broadcastable(
     });
 }
 
+interface ICommand { 
+    method: string;
+    parameters: any[];
+}
+
 /*
 Currently non-functional, needs a server to be running somewhere.
 
@@ -75,6 +80,32 @@ export class BitcoinNodeManager {
         if (this.next_periodic_check != null)
             clearTimeout(this.next_periodic_check);
     }
+
+    /**
+     * Execute a Bitcoin rpc call
+     * @param command { method: string, parameters: any[] }
+     * @returns result of the command or throws an error
+     */
+    async execute(command: ICommand) {
+        const [result] = await window.electron.bitcoin_command([command]);
+        if (result === undefined) {
+            throw new Error('Unexpected result returned');
+        }
+        if (result?.name === 'RpcError') {
+            throw result;
+        }
+        return result;
+    }
+
+    /**
+     * Execute a batched Bitcoin rpc call
+     * @param commands [{ method: string, parameters: any[] },...]
+     * @returns returns an array of results, results can include error objects
+     */
+    async executeBatch(commands: ICommand[]) {
+        return window.electron.bitcoin_command(commands);
+    }
+
     async periodic_check() {
         const contract = this.props.current_contract;
         console.info('PERIODIC CONTRACT CHECK');
@@ -108,6 +139,7 @@ export class BitcoinNodeManager {
         }
     }
 
+    // TODO: make this not static so we can use `execute` directly instead of `bitcoin_command`
     static async fund_out(tx: Transaction): Promise<Transaction> {
         const result = await window.electron.bitcoin_command([
             { method: 'fundrawtransaction', parameters: [tx.toHex()] },
@@ -119,6 +151,7 @@ export class BitcoinNodeManager {
         return Transaction.fromHex(hex);
     }
 
+    // TODO: make this not static so we can use `execute` directly instead of `bitcoin_command`
     static async fetch_utxo(t: TXID, n: number): Promise<QueriedUTXO | null> {
         const txout = (
             await window.electron.bitcoin_command([
@@ -136,60 +169,25 @@ export class BitcoinNodeManager {
         };
     }
     async check_balance(): Promise<number> {
-        const [result] = await window.electron.bitcoin_command([
-            { method: 'getbalance', parameters: [] },
-        ]);
-        if (result.name === 'RpcError') {
-            throw result;
-        }
-        return result;
+        return this.execute({ method: 'getbalance', parameters: [] });
     }
     async blockchaininfo(): Promise<any> {
-        const [result] = await window.electron.bitcoin_command([
-            { method: 'getblockchaininfo', parameters: [] },
-        ]);
-        if (result.name === 'RpcError') {
-            throw result;
-        }
-        return result;
+        return this.execute({ method: 'getblockchaininfo', parameters: [] });
     }
     async get_new_address(): Promise<string> {
-        const [result] = await window.electron.bitcoin_command([
-            { method: 'getnewaddress', parameters: [] },
-        ]);
-        if (result.name === 'RpcError') {
-            throw result;
-        }
-        return result;
+        return this.execute({ method: 'getnewaddress', parameters: [] });
     }
 
     async send_to_address(amount: number, address: string): Promise<void> {
-        return (
-            await window.electron.bitcoin_command([
-                { method: 'sendtoaddress', parameters: [address, amount] },
-            ])
-        )[0];
+        return this.execute({ method: 'sendtoaddress', parameters: [address, amount] });
     }
 
     async list_transactions(count: number): Promise<any> {
-        const [result] = await window.electron.bitcoin_command([
-            { method: 'listtransactions', parameters: ['*', count] },
-        ]);
-        if (result.name === 'RpcError') {
-            throw result;
-        }
-        return result
+        return this.execute({ method: 'listtransactions', parameters: ['*', count] });
     }
     async generate_blocks(n: number): Promise<void> {
         const addr = await this.get_new_address();
-        console.log(addr);
-        const [result] = await window.electron.bitcoin_command([
-            { method: 'generatetoaddress', parameters: [n, addr] },
-        ]);
-        if (result.name === 'RpcError') {
-            throw result;
-        }
-        return result;
+        return this.execute({ method: 'generatetoaddress', parameters: [n, addr] });
     }
     // get info about transactions
     async get_confirmed_transactions(
@@ -205,7 +203,7 @@ export class BitcoinNodeManager {
                 };
             });
         if (txids.length > 0) {
-            let results = await window.electron.bitcoin_command(txids);
+            let results = await this.executeBatch(txids);
             // TODO: Configure Threshold
             results = results
                 .filter((txdata: any) => txdata.confirmations ?? 0 > 1)

--- a/src/Data/BitcoinStatusBar.tsx
+++ b/src/Data/BitcoinStatusBar.tsx
@@ -9,6 +9,7 @@ interface BitcoinStatusBarProps {
     api: BitcoinNodeManager;
 }
 export function BitcoinStatusBar(props: BitcoinStatusBarProps) {
+    const theme = useTheme();
     const freq = useSelector(selectNodePollFreq);
     const [balance, setBalance] = React.useState<number>(0);
     const [blockchaininfo, setBlockchaininfo] = React.useState<any>(null);
@@ -17,11 +18,23 @@ export function BitcoinStatusBar(props: BitcoinStatusBarProps) {
         let mounted = true;
         const periodic_update_stats = async () => {
             next = null;
-            const balance: number = await props.api.check_balance();
-            const info = await props.api.blockchaininfo();
-            console.log(balance);
-            setBalance(balance);
-            setBlockchaininfo(info);
+            try {
+                const balance = await props.api.check_balance();
+                setBalance(balance);
+            } catch (err) {
+                console.error(err);
+                setBalance(0);
+            }
+
+            try {
+                const info = await props.api.blockchaininfo();
+                console.log(balance);
+                setBlockchaininfo(info);
+            } catch (err) {
+                console.error(err);
+                setBlockchaininfo(null);
+            }
+
             let prefs = freq;
             prefs = clamp(prefs, 5, 5 * 60);
             if (mounted) next = setTimeout(periodic_update_stats, prefs * 1000);
@@ -32,7 +45,7 @@ export function BitcoinStatusBar(props: BitcoinStatusBarProps) {
             if (next !== null) clearTimeout(next);
         };
     }, []);
-    const theme = useTheme();
+
     const network = blockchaininfo?.chain ?? 'disconnected';
     const headers = blockchaininfo?.headers ?? '?';
     const blocks = blockchaininfo?.headers ?? '?';
@@ -55,10 +68,10 @@ export function BitcoinStatusBar(props: BitcoinStatusBarProps) {
                     <div>chain: {network}</div>
                 </Typography>
                 <Typography variant="h6" color="inherit" component="div">
-                    <div>balance: {balance} BTC</div>
+                    <div style={{ marginLeft: '0.5em' }}>balance: {balance} BTC</div>
                 </Typography>
                 <Typography variant="h6" color="inherit" component="div">
-                    <div>
+                    <div style={{ marginLeft: '0.5em' }}>
                         processed: {blocks}/{headers}
                     </div>
                 </Typography>

--- a/src/UX/AppNavbar.tsx
+++ b/src/UX/AppNavbar.tsx
@@ -263,7 +263,8 @@ function NodeMenu(props: { bitcoin_node_manager: BitcoinNodeManager }) {
                 <MenuItem
                     onClick={() => {
                         close();
-                        props.bitcoin_node_manager.generate_blocks(10);
+                        props.bitcoin_node_manager.generate_blocks(10)
+                            .catch(err => console.error(err));
                     }}
                 >
                     Generate 10 Blocks

--- a/src/Wallet/Wallet.tsx
+++ b/src/Wallet/Wallet.tsx
@@ -44,25 +44,43 @@ export function Wallet(props: { bitcoin_node_manager: BitcoinNodeManager }) {
     const [amount, setAmount] = React.useState(0);
     const [address, setAddress] = React.useState<string | null>(null);
     const [transactions, setTransactions] = React.useState<TxInfo[]>([]);
+
     React.useEffect(() => {
         let cancel = false;
         const update = async () => {
             if (cancel) return;
-            const amt = await props.bitcoin_node_manager.check_balance();
-            setAmount(amt);
+            try {
+                const amt = await props.bitcoin_node_manager.check_balance();
+                setAmount(amt);
+            } catch (err: any) {
+                console.error(err);
+                setAmount(0);
+            }
 
-            const txns = await props.bitcoin_node_manager.list_transactions(10);
-            setTransactions(txns);
+            try {
+                const txns = await props.bitcoin_node_manager.list_transactions(10);
+                setTransactions(txns);
+            } catch (err) {
+                console.error(err);
+                setTransactions([]);
+            }
             setTimeout(update, 5000);
         };
+
         update();
         return () => {
             cancel = true;
         };
-    });
+    }, []);
+
     const get_address = async () => {
-        const address = await props.bitcoin_node_manager.get_new_address();
-        setAddress(address);
+        try {
+            const address = await props.bitcoin_node_manager.get_new_address();
+            setAddress(address);
+        } catch (err) {
+            // console.error(err);
+            setAddress(null);
+        }
     };
     const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (
         event


### PR DESCRIPTION
Currently whenever a wallet is locked the app crashes because functions that set the state are unable to update the state with that data.

Another thing is that inside a `Wallet.tsx` the `useEffect` hook doesn't have any values in the dependency array meaning the hook will be triggered more often than necessary (only needs to be executed once per render) but on every component update which is significantly more often.