### PR TITLE
bump electron to 13.5.2 to fix seccomp error

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ via `bitcoin-cli`.
 
 ### Run Sapio
 
-In one terminal run below code: `yarn start-react`
+In one terminal run code: `yarn start-react`
 
 After previous command finishes compiling run: `yarn start-electron`
-
-If `start-electron` command doesn't work you can try: `yarn start-electron --disable-seccomp-filter-sandbox`
 
 ## Connecting With Sapio & Bitcoin
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     },
     "devDependencies": {
         "babel-eslint": "^10.1.0",
-        "electron": "^13.1.8",
+        "electron": "13.5.2",
         "electron-devtools-installer": "^3.2.0",
         "eslint-config-react": "^1.1.7",
         "eslint-config-react-app": "^6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6389,10 +6389,10 @@ electron-to-chromium@^1.3.793:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.802.tgz#0afa989321de3e904ac653ee79e0d642883731a1"
   integrity sha512-dXB0SGSypfm3iEDxrb5n/IVKeX4uuTnFHdve7v+yKJqNpEP0D4mjFJ8e1znmSR+OOVlVC+kDO6f2kAkTFXvJBg==
 
-electron@^13.1.8:
-  version "13.1.9"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.1.9.tgz#668e2632b81e9fa21edfd32876282d3e2ff7fd76"
-  integrity sha512-By4Zb72XNQLrPb70BXdIW3NtEHFwybP5DIQjohnCxOYONq5vojuHjNcTuWnBgMvwQ2qwykk6Tw5EwF2Pt0CWjA==
+electron@13.5.2:
+  version "13.5.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.5.2.tgz#5c5826e58a5e12bb5ca8047b789d07b45260ecbc"
+  integrity sha512-CPakwDpy5m8dL0383F5uJboQcVtn9bT/+6/wdDKo8LuTUO9aER1TF41v7feZgZW2c+UwoGPWa814ElSQ3qta2A==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
Bumping electron version fixes the issue where a `--disable-seccomp-filter-sandbox` or `--no-sandbox` is necessary in order to start the app. After this change dev on any OS will be able to run `yarn start-electron`.

More info on the issue: https://github.com/electron/electron/pull/31091

cc @prayank23 