### PR TITLE
Workspace WASM Modules

### DIFF
--- a/desktop/handlers.ts
+++ b/desktop/handlers.ts
@@ -40,8 +40,8 @@ export default function (window: BrowserWindow) {
         return get_emulator_log();
     });
 
-    ipcMain.handle('sapio::load_contract_list', async (event) => {
-        const contracts = await sapio.list_contracts();
+    ipcMain.handle('sapio::load_contract_list', async (event, workspace) => {
+        const contracts = await sapio.list_contracts(workspace);
         return contracts;
     });
     ipcMain.handle(
@@ -61,7 +61,7 @@ export default function (window: BrowserWindow) {
         return await sapio.show_config();
     });
 
-    ipcMain.handle('sapio::load_wasm_plugin', (event) => {
+    ipcMain.handle('sapio::load_wasm_plugin', (event, workspace) => {
         const plugins = dialog.showOpenDialogSync({
             properties: ['openFile', 'multiSelections'],
             filters: [{ extensions: ['wasm'], name: 'WASM' }],
@@ -69,7 +69,7 @@ export default function (window: BrowserWindow) {
         const errs = [];
         if (!plugins || !plugins.length) return { err: 'No Plugin Selected' };
         for (const plugin of plugins) {
-            const loaded = sapio.load_contract_file_name(plugin);
+            const loaded = sapio.load_contract_file_name(workspace, plugin);
             if ('err' in loaded) {
                 return loaded;
             }

--- a/desktop/preload.ts
+++ b/desktop/preload.ts
@@ -29,16 +29,16 @@ function create_contract(
 function open_contract_from_file(): Promise<Result<string>> {
     return ipcRenderer.invoke('sapio::open_contract_from_file');
 }
-function load_wasm_plugin(): Promise<Result<null>> {
-    return ipcRenderer.invoke('sapio::load_wasm_plugin');
+function load_wasm_plugin(workspace: string): Promise<Result<null>> {
+    return ipcRenderer.invoke('sapio::load_wasm_plugin', workspace);
 }
 
 function show_config(): Promise<Result<string>> {
     return ipcRenderer.invoke('sapio::show_config');
 }
 
-function load_contract_list() {
-    return ipcRenderer.invoke('sapio::load_contract_list');
+function load_contract_list(workspace: string) {
+    return ipcRenderer.invoke('sapio::load_contract_list', workspace);
 }
 
 const psbt = {

--- a/src/AppSlice.tsx
+++ b/src/AppSlice.tsx
@@ -147,4 +147,8 @@ export const selectHasEffect = createDeepEqualSelector(
 
 export const selectShowing: (state: RootState) => Pages = (state: RootState) =>
     state.appReducer.showing;
+
+export const selectWorkspace: (state: RootState) => string = (state) =>
+    state.walletReducer.workspace;
+
 export default appSlice.reducer;

--- a/src/UX/AppNavbar.tsx
+++ b/src/UX/AppNavbar.tsx
@@ -11,10 +11,11 @@ import {
     Paper,
 } from '@mui/material';
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
     create_contract_from_file,
     recreate_contract,
+    selectWorkspace,
     switch_showing,
     toggle_status_bar,
 } from '../AppSlice';
@@ -156,6 +157,7 @@ function MainScreens() {
 }
 function ContractMenu(props: { relayout: () => void }) {
     const dispatch = useDispatch();
+    const workspace = useSelector(selectWorkspace);
     const contractRef = React.useRef<HTMLLIElement>(null);
     const [contracts_open, setContractsOpen] = React.useState(false);
 
@@ -208,7 +210,7 @@ function ContractMenu(props: { relayout: () => void }) {
                 <MenuItem
                     onClick={() => {
                         setContractsOpen(false);
-                        window.electron.sapio.load_wasm_plugin();
+                        window.electron.sapio.load_wasm_plugin(workspace);
                     }}
                 >
                     Load WASM Plugin
@@ -217,7 +219,9 @@ function ContractMenu(props: { relayout: () => void }) {
                     onClick={async () => {
                         setContractsOpen(false);
                         const apis =
-                            await window.electron.sapio.load_contract_list();
+                            await window.electron.sapio.load_contract_list(
+                                workspace
+                            );
                         if ('err' in apis) {
                             alert(apis.err);
                             return;

--- a/src/common/preload_interface.d.ts
+++ b/src/common/preload_interface.d.ts
@@ -99,9 +99,9 @@ export type preloads = {
             args: string
         ) => Promise<Result<string | null>>;
         show_config: () => Promise<Result<string>>;
-        load_wasm_plugin: () => Promise<Result<null>>;
+        load_wasm_plugin: (workspace: string) => Promise<Result<null>>;
         open_contract_from_file: () => Promise<Result<string>>;
-        load_contract_list: () => Promise<Result<API>>;
+        load_contract_list: (workspace: string) => Promise<Result<API>>;
         compiled_contracts: {
             list: (workspace: string) => Promise<string[]>;
             trash: (workspace: string, file_name: string) => Promise<void>;


### PR DESCRIPTION
Builds on https://github.com/sapio-lang/sapio/pull/199

Makes it so that the contract modules are no longer loaded globally, but get loaded per-workspace.

This is less "efficient", but it is better isolation between workspaces, so is good.

If space usage becomes a real concern, we could (in the future!), have a global cache that we symlink against, but this approach is best for now!.